### PR TITLE
feat: Use `thiserror` 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.70.0"
 exclude = ["images/", "tests/", "miette-derive/"]
 
 [dependencies]
-thiserror = { version = "1.0", git = "https://github.com/bitwalker/thiserror", branch = "no-std", default-features = false }
+thiserror = { version = "2.0", default-features = false }
 miette-derive = { path = "miette-derive", version = "=7.1.0", optional = true }
 unicode-width = { version = "0.1", default-features = false }
 cfg-if = "1.0.0"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,0 @@
-use rustc_version::{version_meta, Channel};
-
-fn main() {
-    if let Channel::Nightly = version_meta().unwrap().channel {
-        println!("cargo:rustc-cfg=nightly")
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,7 +778,7 @@ extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
 
-pub use thiserror::StdError;
+pub use core::error::Error as StdError;
 
 #[cfg(feature = "derive")]
 pub use miette_derive::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(missing_docs, missing_debug_implementations, nonstandard_style)]
 #![warn(unreachable_pub, rust_2018_idioms)]
 #![no_std]
-#![cfg_attr(feature = "nightly", feature(error_in_core))]
 //! You run miette? You run her code like the software? Oh. Oh! Error code for
 //! coder! Error code for One Thousand Lines!
 //!

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -30,7 +30,7 @@ pub fn set_panic_hook() {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("{0}{}", Panic::backtrace())]
+#[error("{0}{panic}", panic = Panic::backtrace())]
 #[diagnostic(help("set the `RUST_BACKTRACE=1` environment variable to display a backtrace."))]
 struct Panic(String);
 


### PR DESCRIPTION
Minimal changes to update miette to use `thiserror` 2.0 and re-export `core::error::Error` as `StdError` now instead of the potentially custom implementation from `miden_thiserror`.

I'm guessing that the `no-std` branch was used to publish current `miden-miette` so I branched off of that.

The changes in this PR are successful (with warnings):
- `cargo check --no-default-features`
- `cargo check --features std`

`cargo check --all-features` does not work but it does not work on the `no-std` branch for the same reasons, so I assume this somehow fine.

I did a test run in a miden-vm PR to see if these changes pass CI and they do: https://github.com/0xPolygonMiden/miden-vm/actions/runs/12081536640